### PR TITLE
Add special handling of length 1 inputs to parse to single value

### DIFF
--- a/tests/testthat/test-generate-cpp.R
+++ b/tests/testthat/test-generate-cpp.R
@@ -100,3 +100,21 @@ test_that("csv structure can be validated", {
     paste("All columns after 'dims' must be a dimension column, got 'other'.",
           "Check 'inputs.csv'."))
 })
+
+test_that("can generate length 1 inputs", {
+  input <- utils::read.csv(frogger_file("cpp_generation/model_input.csv"))
+  length_1_input <- data.frame(r_name = "len1", cpp_name = "len_1",
+                               type = "real_type", value = NA_character_,
+                               convert_base = FALSE, dims = 1, dim1 = 1,
+                               dim2 = "", dim3 = "", dim4 = "")
+  input <- rbind.data.frame(input, length_1_input)
+  t_input <- tempfile()
+  write.csv(input, t_input)
+  t_dest <- tempfile()
+
+  generate_input_interface(t_dest, t_input)
+  result <- readLines(t_dest)
+  expect_true(any(grepl(
+    "const real_type len_1 = Rcpp::as<real_type>\\(data\\[\"len1\"\\]\\)",
+    result)))
+})


### PR DESCRIPTION
After this PR if in your `model_input.csv` you have an input which has 1 dimension of length 1 it will parse it as it's type not as a tensor. e.g. if a dim 1 length 1 `real_type` it will create a `real_type` not a `TensorMap1<real_type>`