### PR TITLE
Update HivModelSimulation to AdultHivModelSimulation for clarity

### DIFF
--- a/inst/include/README.md
+++ b/inst/include/README.md
@@ -1,5 +1,9 @@
 This directory contains header files which can be imported by other R packages using the `LinkingTo:` directive in the `DESCRIPTION` file. See https://r-pkgs.org/src.html?q=linkingto#cpp-import
 
+This directory contains two subdirectories:
+* `generated` - this contains automatically generated code and should not be modified by hand, see "Development" vignette for details
+* `models` - this directory contains the model implementation code
+
 _Note:_ if this contains a file `leapfrog.h` (the same as the package name), then when building the package `Rcpp::compileAttributes()` will add the line `#include ../include/leapfrog.h` in [`src/RcppExports.cpp`](../../src/RcppExports.cpp). This creates a clash with multiple loading of some Eigen libraries on Windows (only; fine on Linux and Mac environment).
 
 I am unsure why at the moment, but for now avoid `leapfrog.h` until resolved.

--- a/inst/include/frogger.hpp
+++ b/inst/include/frogger.hpp
@@ -4,7 +4,7 @@
 #include "generated/config_mixer.hpp"
 #include "models/general_demographic_projection.hpp"
 #include "models/hiv_demographic_projection.hpp"
-#include "models/hiv_model_simulation.hpp"
+#include "models/adult_hiv_model_simulation.hpp"
 #include "models/child_model_simulation.hpp"
 
 namespace leapfrog {
@@ -30,7 +30,7 @@ struct Leapfrog {
   ) {
     const auto opts = get_opts(hiv_steps, t_ART_start, is_midyear_projection);
     const auto pars = Config::get_pars(data, opts, time_steps);
-    
+
     auto state = run_model(time_steps, save_steps, pars, opts);
 
     const int output_size = Config::get_build_output_size(0);
@@ -38,7 +38,7 @@ struct Leapfrog {
     Rcpp::CharacterVector names(output_size);
     Config::build_output(ret, names, 0, state, save_steps.size());
     ret.attr("names") = names;
-  
+
     return ret;
   };
 
@@ -108,7 +108,7 @@ struct Leapfrog {
   static void project_year(Args& args) {
     GeneralDemographicProjection<Config> general_dp(args);
     HivDemographicProjection<Config> hiv_dp(args);
-    HivModelSimulation<Config> hiv_sim(args);
+    AdultHivModelSimulation<Config> hiv_sim(args);
     ChildModelSimulation<Config> child_sim(args);
 
     if constexpr (ModelVariant::run_demographic_projection) {

--- a/inst/include/models/adult_hiv_model_simulation.hpp
+++ b/inst/include/models/adult_hiv_model_simulation.hpp
@@ -4,16 +4,16 @@
 
 namespace leapfrog {
 
-template<typename Config>	
-concept HivModelSimulationEnabled = RunDemographicProjection<Config> && RunHivSimulation<Config>;
+template<typename Config>
+concept AdultHivModelSimulationEnabled = RunDemographicProjection<Config> && RunHivSimulation<Config>;
 
 template<typename Config>
-struct HivModelSimulation {
-  HivModelSimulation(...) {};
+struct AdultHivModelSimulation {
+  AdultHivModelSimulation(...) {};
 };
 
-template<HivModelSimulationEnabled Config>
-struct HivModelSimulation<Config> {
+template<AdultHivModelSimulationEnabled Config>
+struct AdultHivModelSimulation<Config> {
   using real_type = typename Config::real_type;
   using ModelVariant = typename Config::ModelVariant;
   using SS = Config::SS;
@@ -47,7 +47,7 @@ struct HivModelSimulation<Config> {
 
   // only exposing the constructor and some methods
   public:
-  HivModelSimulation(Args& args):
+  AdultHivModelSimulation(Args& args):
     t(args.t),
     pars(args.pars),
     state_curr(args.state_curr),


### PR DESCRIPTION
Closes #85 see that for description

This PR will
* Rename the `hiv_model_simulation.hpp` to `adult_hiv_model_simulation.hpp` as agreed in issue
* Add notes into README about generated vs model code