### PR TITLE
Compile child model for DLL

### DIFF
--- a/c_interface/c_interface.cpp
+++ b/c_interface/c_interface.cpp
@@ -59,7 +59,7 @@ DllExport HRESULT WINAPI run_aim(leapfrog::internal::CParams<double> &data,
    leapfrog::internal::CState<double> &out,
    CallbackFunction error_handler) {
 #pragma EXPORT
-return fit_model<leapfrog::HivFullAgeStratification>(data, options, out, error_handler);
+return fit_model<leapfrog::ChildModel>(data, options, out, error_handler);
 }
 
 template <typename ModelVariant>


### PR DESCRIPTION
Required for #200 but that only be closed once mapping is done in spectrum desktop. Builds on #209 