### PR TITLE
Remove std format and get wheels building

### DIFF
--- a/.github/workflows/leapfrog-py-deploy.yaml
+++ b/.github/workflows/leapfrog-py-deploy.yaml
@@ -9,10 +9,6 @@ on:
     types:
       - published
 
-defaults:
-  run:
-    working-directory: leapfrog-py
-
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
@@ -25,15 +21,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Used to host cibuildwheel
+      - uses: actions/setup-python@v5
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==3.0.1
+
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.19.1
-        with:
-          package-dir: leapfrog-py
+        run: python -m cibuildwheel --output-dir wheelhouse leapfrog-py
 
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
-          path: ./wheelhouse/*.whl
+          path: wheelhouse/*.whl
 
   build_sdist:
     name: Build source distribution
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build sdist
-        run: pipx run build --sdist
+        run: pipx run build --sdist leapfrog-py
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/leapfrog-py-deploy.yaml
+++ b/.github/workflows/leapfrog-py-deploy.yaml
@@ -54,25 +54,25 @@ jobs:
           name: cibw-sdist
           path: dist/*.tar.gz
 
-  upload_pypi:
-    needs: [build_wheels, build_sdist]
-    runs-on: ubuntu-latest
-    environment: pypi
-    permissions:
-      id-token: write
-    if: github.event_name == 'release' && github.event.action == 'published'
-    # or, alternatively, upload to PyPI on every tag starting with 'v' (remove on: release above to use this)
-    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          # unpacks all CIBW artifacts into dist/
-          pattern: cibw-*
-          path: dist
-          merge-multiple: true
-
-      - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          # To test: repository-url: https://test.pypi.org/legacy/
-          repository-url: https://upload.pypi.org/legacy/
+  # upload_pypi:
+  #   needs: [build_wheels, build_sdist]
+  #   runs-on: ubuntu-latest
+  #   environment: pypi
+  #   permissions:
+  #     id-token: write
+  #   if: github.event_name == 'release' && github.event.action == 'published'
+  #   # or, alternatively, upload to PyPI on every tag starting with 'v' (remove on: release above to use this)
+  #   # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+  #
+  #   steps:
+  #     - uses: actions/download-artifact@v4
+  #       with:
+  #         # unpacks all CIBW artifacts into dist/
+  #         pattern: cibw-*
+  #         path: dist
+  #         merge-multiple: true
+  #
+  #     - uses: pypa/gh-action-pypi-publish@release/v1
+  #       with:
+  #         # To test: repository-url: https://test.pypi.org/legacy/
+  #         repository-url: https://upload.pypi.org/legacy/

--- a/.github/workflows/leapfrog-py-deploy.yaml
+++ b/.github/workflows/leapfrog-py-deploy.yaml
@@ -5,9 +5,7 @@ on:
   push:
     branches:
       - main
-  release:
-    types:
-      - published
+      - leapfrog-py-4
 
 jobs:
   build_wheels:
@@ -55,13 +53,12 @@ jobs:
   upload_pypi:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
-    environment: pypi
+    environment:
+      name: pypi
+      url: https://pypi.org/p/leapfrog-py
     permissions:
-      id-token: write
-    if: github.event_name == 'release' && github.event.action == 'published'
-    # or, alternatively, upload to PyPI on every tag starting with 'v'
-    # (remove on: release above to use this)
-    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
 
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/leapfrog-py-deploy.yaml
+++ b/.github/workflows/leapfrog-py-deploy.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         # macos-13 is an intel runner, macos-14 is apple silicon
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        os: [ubuntu-latest, windows-latest, macos-14]
 
     steps:
       - uses: actions/checkout@v4
@@ -29,10 +29,6 @@ jobs:
         uses: pypa/cibuildwheel@v2.19.1
         with:
           package-dir: leapfrog-py
-        env:
-          # Issue with compiling pybind11 eigen header as it has an invalid
-          # conversion from size_t to int
-          CIBW_SKIP: "pp38-manylinux_i686 pp39-manylinux_i686 pp310-manylinux_i686"
 
       - uses: actions/upload-artifact@v4
         with:
@@ -52,7 +48,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-sdist
-          path: dist/*.tar.gz
+          path: leapfrog-py/dist/*.tar.gz
 
   # upload_pypi:
   #   needs: [build_wheels, build_sdist]

--- a/.github/workflows/leapfrog-py-deploy.yaml
+++ b/.github/workflows/leapfrog-py-deploy.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         # macos-13 is an intel runner, macos-14 is apple silicon
-        os: [ubuntu-latest, windows-latest, macos-14]
+        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/leapfrog-py-deploy.yaml
+++ b/.github/workflows/leapfrog-py-deploy.yaml
@@ -50,25 +50,27 @@ jobs:
           name: cibw-sdist
           path: leapfrog-py/dist/*.tar.gz
 
-  # upload_pypi:
-  #   needs: [build_wheels, build_sdist]
-  #   runs-on: ubuntu-latest
-  #   environment: pypi
-  #   permissions:
-  #     id-token: write
-  #   if: github.event_name == 'release' && github.event.action == 'published'
-  #   # or, alternatively, upload to PyPI on every tag starting with 'v' (remove on: release above to use this)
-  #   # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-  #
-  #   steps:
-  #     - uses: actions/download-artifact@v4
-  #       with:
-  #         # unpacks all CIBW artifacts into dist/
-  #         pattern: cibw-*
-  #         path: dist
-  #         merge-multiple: true
-  #
-  #     - uses: pypa/gh-action-pypi-publish@release/v1
-  #       with:
-  #         # To test: repository-url: https://test.pypi.org/legacy/
-  #         repository-url: https://upload.pypi.org/legacy/
+  upload_pypi:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    if: github.event_name == 'release' && github.event.action == 'published'
+    # or, alternatively, upload to PyPI on every tag starting with 'v'
+    # (remove on: release above to use this)
+    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          # unpacks all CIBW artifacts into dist/
+          pattern: cibw-*
+          path: dist
+          merge-multiple: true
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # To test: repository-url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/legacy/
+          # repository-url: https://upload.pypi.org/legacy/

--- a/.github/workflows/leapfrog-py-deploy.yaml
+++ b/.github/workflows/leapfrog-py-deploy.yaml
@@ -71,6 +71,6 @@ jobs:
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          # To test: repository-url: https://test.pypi.org/legacy/
-          repository-url: https://test.pypi.org/legacy/
-          # repository-url: https://upload.pypi.org/legacy/
+          # To test
+          # repository-url: https://test.pypi.org/legacy/
+          repository-url: https://upload.pypi.org/legacy/

--- a/.github/workflows/leapfrog-py-deploy.yaml
+++ b/.github/workflows/leapfrog-py-deploy.yaml
@@ -3,9 +3,10 @@ name: Build and upload to PyPI
 on:
   workflow_dispatch:
   push:
+    tags:
+      - "v*"
     branches:
       - main
-      - leapfrog-py-4
 
 jobs:
   build_wheels:
@@ -58,7 +59,7 @@ jobs:
       url: https://pypi.org/p/leapfrog-py
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v')
 
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/leapfrog-py-deploy.yaml
+++ b/.github/workflows/leapfrog-py-deploy.yaml
@@ -23,6 +23,7 @@ jobs:
 
       # Used to host cibuildwheel
       - uses: actions/setup-python@v5
+        with: "3.13"
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==3.0.1

--- a/.github/workflows/leapfrog-py-deploy.yaml
+++ b/.github/workflows/leapfrog-py-deploy.yaml
@@ -23,7 +23,8 @@ jobs:
 
       # Used to host cibuildwheel
       - uses: actions/setup-python@v5
-        with: "3.13"
+        with:
+          python-version: "3.13"
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==3.0.1

--- a/cpp_generation/templates/cpp/c_interface/c_adapters.j2
+++ b/cpp_generation/templates/cpp/c_interface/c_adapters.j2
@@ -4,8 +4,8 @@
 #pragma once
 
 #include <filesystem>
+#include <sstream>
 #include <string_view>
-#include <format>
 #include <stdexcept>
 
 #include "../../array/array.h"
@@ -19,12 +19,10 @@ template<typename T, size_t Rank>
 auto read_data(T* data, int length, std::string_view name, nda::shape_of_rank<Rank> shape) {
   const auto size = shape.flat_max() + 1;
   if (length != size) {
-    throw std::invalid_argument(
-      std::format(
-        "Input data '{}' is the wrong size. Received array of length '{}', expected '{}'.",
-        name, length, size
-      )
-    );
+    std::ostringstream oss;
+    oss << "Input data '" << name << "' is the wrong size. "
+        << "Received array of length '" << length << "', expected '" << size << "'.";
+    throw std::invalid_argument(oss.str());
   }
   return nda::array_ref_of_rank<T, Rank>(data, shape);
 }
@@ -44,12 +42,10 @@ void write_data(const nda::array<T, Shape>& array, T* output, int length, std::s
   std::size_t totalSize = array.size();
 
   if (length != totalSize) {
-    throw std::invalid_argument(
-      std::format(
-        "Output data '{}' is the wrong size. Received array of length '{}', expected '{}'.",
-        name, length, totalSize
-      )
-    );
+    std::ostringstream oss;
+    oss << "Output data '" << name << "' is the wrong size. "
+        << "Received array of length '" << length << "', expected '" << totalSize << "'.";
+    throw std::invalid_argument(oss.str());
   }
   std::copy(dataPtr, dataPtr + totalSize, output);
 }

--- a/cpp_generation/templates/cpp/py_interface/py_adapters.j2
+++ b/cpp_generation/templates/cpp/py_interface/py_adapters.j2
@@ -5,9 +5,9 @@
 
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
+#include <sstream>
 #include <stdexcept>
 #include <iostream>
-#include <format>
 
 #include "../config_mixer.hpp"
 
@@ -25,12 +25,10 @@ nda::array_ref_of_rank<T, Rank> parse_data(const nb::dict& data, char const* key
   int expected_length = shape.flat_max() + 1;
 
   if (actual_length < expected_length) {
-    throw std::invalid_argument(
-      std::format(
-        "Invalid size of data for '{}', expected {} got {}",
-        key, expected_length, actual_length
-      )
-    );
+    std::ostringstream oss;
+    oss << "Invalid size of data for '" << key << "', expected " << expected_length
+        << " got " << actual_length;
+    throw std::invalid_argument(oss.str());
   }
   return { array_data, shape };
 }

--- a/leapfrog-py/README.md
+++ b/leapfrog-py/README.md
@@ -2,7 +2,9 @@
 
 ## Installation
 
-We are not currently publishing to PyPi.
+```bash
+pip install leapfrog-py
+```
 
 ## Usage
 

--- a/leapfrog-py/pyproject.toml
+++ b/leapfrog-py/pyproject.toml
@@ -35,3 +35,7 @@ dev = [
     "docopt>=0.6.2",
     "pytest>=8.3.5",
 ]
+
+# Needed for full C++17 support on macOS
+[tool.cibuildwheel.macos.environment]
+MACOSX_DEPLOYMENT_TARGET = "10.14"

--- a/leapfrog-py/pyproject.toml
+++ b/leapfrog-py/pyproject.toml
@@ -39,3 +39,14 @@ dev = [
 # Needed for full C++17 support on macOS
 [tool.cibuildwheel.macos.environment]
 MACOSX_DEPLOYMENT_TARGET = "10.14"
+
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Implementation :: PyPy",
+]

--- a/r-package/inst/include/frogger.hpp
+++ b/r-package/inst/include/frogger.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <sstream>
 #include "array/array.h"
 #include "generated/model_variants.hpp"
 #include "generated/config_mixer.hpp"
@@ -9,8 +10,6 @@
 #include "models/child_model_simulation.hpp"
 #include "options.hpp"
 #include "initial_year.hpp"
-
-#include <format>
 
 namespace leapfrog {
 
@@ -51,9 +50,11 @@ struct Leapfrog {
     const auto min_output_year = std::min_element(std::begin(output_years),
                                                   std::end(output_years));
     if (*min_output_year != opts.proj_start_year && *min_output_year <= simulation_start_year) {
-      throw std::invalid_argument(
-        std::format("Cannot output year '{}'. Output years must be later than simulation start year '{}'.",
-          *min_output_year, simulation_start_year));
+      std::ostringstream oss;
+      oss << "Cannot output year '" << *min_output_year << "'. "
+          << "Output years must be later than simulation start year"
+          << " '" << simulation_start_year << "'.";
+      throw std::invalid_argument(oss.str());
     }
     auto state = initial_state;
     auto state_next = state;

--- a/r-package/inst/include/generated/c_interface/c_adapters.hpp
+++ b/r-package/inst/include/generated/c_interface/c_adapters.hpp
@@ -6,8 +6,8 @@
 #pragma once
 
 #include <filesystem>
+#include <sstream>
 #include <string_view>
-#include <format>
 #include <stdexcept>
 
 #include "../../array/array.h"
@@ -21,12 +21,10 @@ template<typename T, size_t Rank>
 auto read_data(T* data, int length, std::string_view name, nda::shape_of_rank<Rank> shape) {
   const auto size = shape.flat_max() + 1;
   if (length != size) {
-    throw std::invalid_argument(
-      std::format(
-        "Input data '{}' is the wrong size. Received array of length '{}', expected '{}'.",
-        name, length, size
-      )
-    );
+    std::ostringstream oss;
+    oss << "Input data '" << name << "' is the wrong size. "
+        << "Received array of length '" << length << "', expected '" << size << "'.";
+    throw std::invalid_argument(oss.str());
   }
   return nda::array_ref_of_rank<T, Rank>(data, shape);
 }
@@ -46,12 +44,10 @@ void write_data(const nda::array<T, Shape>& array, T* output, int length, std::s
   std::size_t totalSize = array.size();
 
   if (length != totalSize) {
-    throw std::invalid_argument(
-      std::format(
-        "Output data '{}' is the wrong size. Received array of length '{}', expected '{}'.",
-        name, length, totalSize
-      )
-    );
+    std::ostringstream oss;
+    oss << "Output data '" << name << "' is the wrong size. "
+        << "Received array of length '" << length << "', expected '" << totalSize << "'.";
+    throw std::invalid_argument(oss.str());
   }
   std::copy(dataPtr, dataPtr + totalSize, output);
 }

--- a/r-package/inst/include/generated/py_interface/py_adapters.hpp
+++ b/r-package/inst/include/generated/py_interface/py_adapters.hpp
@@ -7,9 +7,9 @@
 
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
+#include <sstream>
 #include <stdexcept>
 #include <iostream>
-#include <format>
 
 #include "../config_mixer.hpp"
 
@@ -27,12 +27,10 @@ nda::array_ref_of_rank<T, Rank> parse_data(const nb::dict& data, char const* key
   int expected_length = shape.flat_max() + 1;
 
   if (actual_length < expected_length) {
-    throw std::invalid_argument(
-      std::format(
-        "Invalid size of data for '{}', expected {} got {}",
-        key, expected_length, actual_length
-      )
-    );
+    std::ostringstream oss;
+    oss << "Invalid size of data for '" << key << "', expected " << expected_length
+        << " got " << actual_length;
+    throw std::invalid_argument(oss.str());
   }
   return { array_data, shape };
 }


### PR DESCRIPTION
I have removed std format and updates the build and publish to pypi action, the wheels will automatically build when commit is pushed to main and it will only upload wheels and sdist when we push a tag which also gives us the flexibility to push from a branch if we wish to

i did a run with a tag you can check out the:
* ci workflow: https://github.com/mrc-ide/frogger/actions/runs/16474262959
* published package on test pypi: https://test.pypi.org/project/leapfrog-py