### PR TITLE
Fix issue where FOI formula was setting transmission probabilty to 0

### DIFF
--- a/leapfrog-core/include/models/goals_simulation.hpp
+++ b/leapfrog-core/include/models/goals_simulation.hpp
@@ -780,7 +780,7 @@ public:
 
     i_hv.i_idu_share_prop = p_hv.b_idu_share_prop(t_behav);
 
-    nda::fill(i_hv.func_cure_impact_inf, 1.0);
+    nda::fill(i_hv.func_cure_impact_inf, 0.0);
     nda::fill(i_hv.func_cure_impact_mort_rg, 1.0);
     nda::fill(i_hv.func_cure_impact_mort_all, 1.0);
   }


### PR DESCRIPTION
This was introduced after adding functional cure. Functional cure impact on infectiousness was originally added as a direct multipler. But changed to a (1.0 - func_cure_impact_inf) at some point. Its default value was correctpy updated in one place but not in init_vars_pre_hiv_loop. So it was setting transmission probability to 0.