### PR TITLE
Compare wrapper + working-tree support (issue 19)

### DIFF
--- a/leapfrog-validate/README.md
+++ b/leapfrog-validate/README.md
@@ -3,9 +3,11 @@
 Compare leapfrog model output across git refs, and (eventually) against
 Spectrum. See `.scratch/leapfrog-validation/PRD.md` for the full design;
 this package currently implements the walking skeleton
-(`.scratch/leapfrog-validation/issues/15-walking-skeleton-single-indicator-diff.md`)
-plus the full five-indicator registry and exclusion mechanism
-(`.scratch/leapfrog-validation/issues/17-full-indicator-registry-tolerance-rollup.md`).
+(`.scratch/leapfrog-validation/issues/15-walking-skeleton-single-indicator-diff.md`),
+the full five-indicator registry and exclusion mechanism
+(`.scratch/leapfrog-validation/issues/17-full-indicator-registry-tolerance-rollup.md`),
+and the `compare` directory wrapper plus working-tree support
+(`.scratch/leapfrog-validation/issues/19-compare-wrapper-working-tree.md`).
 
 ## Usage
 
@@ -13,13 +15,34 @@ plus the full five-indicator registry and exclusion mechanism
 uv run leapfrog-validate build-params <ref> <pjnz> -o params.h5
 uv run leapfrog-validate run <ref> params.h5 -o output.h5
 uv run leapfrog-validate diff output-a.h5 output-b.h5
+uv run leapfrog-validate compare <ref> <candidate> --pjnz-dir <dir>
 ```
 
 Each command independently builds `leapfrogr` (and regenerates the C++
 headers it depends on) at the given git ref, in an isolated git worktree
-cached under `--cache-dir` (default `~/.cache/leapfrog-validate`). `<ref>`
-must be a committed ref or SHA -- uncommitted working-tree support is a
-separate, later ticket.
+cached under `--cache-dir` (default `~/.cache/leapfrog-validate`; note this
+is a global option and must come *before* the subcommand, e.g.
+`leapfrog-validate --cache-dir /tmp/cache compare ...`).
+
+`<ref>` accepts a committed git ref/SHA, or the literal value `working-tree`
+for your own current uncommitted checkout -- so you can check "how does my
+in-progress change compare to main" without committing first. A working-tree
+build is cached by a content hash of `leapfrog-core/`, `codegen/`, and
+`leapfrogr/` (the directories that actually feed the build) rather than a
+git SHA, so re-running against the same uncommitted state reuses the cached
+build instead of rebuilding.
+
+### `compare`: running the full pipeline across a directory of PJNZ files
+
+```sh
+uv run leapfrog-validate compare main working-tree --pjnz-dir ./pjnz-corpus
+```
+
+Builds `<ref>` and `<candidate>` once each, then runs `build-params` → `run`
+→ `diff` (all five indicators, `--pjnz <filename-without-extension>` so
+exclusions apply) for every `*.PJNZ` file in `--pjnz-dir`, printing a
+per-indicator verdict and a per-file PASS/FAIL line, plus a summary at the
+end. Exits non-zero if any file fails any indicator.
 
 `diff` applies a hybrid `atol + rtol*|ref|` per-cell tolerance (strict-max
 rollup: any single over-tolerance cell fails that indicator) and, by

--- a/leapfrog-validate/src/leapfrog_validate/cli.py
+++ b/leapfrog-validate/src/leapfrog_validate/cli.py
@@ -4,6 +4,7 @@ Composable primitives, independently invokable: build-params, run, diff.
 See `.scratch/leapfrog-validation/issues/15-walking-skeleton-single-indicator-diff.md`.
 """
 
+import tempfile
 from pathlib import Path
 from typing import Annotated
 
@@ -18,11 +19,11 @@ app = typer.Typer(help="Compare leapfrog model output across git refs.")
 
 DEFAULT_CACHE_DIR = Path.home() / ".cache" / "leapfrog-validate"
 
+REF_HELP = f"Git ref/SHA to build leapfrogr at, or '{git_utils.WORKING_TREE}' for your own uncommitted checkout."
+
 
 def _prepare_ref(repo_root: Path, cache_dir: Path, ref: str) -> BuildWorkspace:
-    sha = git_utils.resolve_ref(repo_root, ref)
-    typer.echo(f"Resolved '{ref}' -> {sha}")
-    worktree = git_utils.ensure_worktree(repo_root, sha, cache_dir)
+    worktree = git_utils.prepare_source(repo_root, cache_dir, ref)
     typer.echo(f"Building leapfrogr at {worktree} ...")
     return build.build_leapfrogr(worktree)
 
@@ -45,7 +46,7 @@ def set_cache_dir(
 @app.command("build-params")
 def build_params_cmd(
     ctx: typer.Context,
-    ref: Annotated[str, typer.Argument(help="Git ref or SHA to build leapfrogr at.")],
+    ref: Annotated[str, typer.Argument(help=REF_HELP)],
     pjnz: Annotated[Path, typer.Argument(exists=True, help="PJNZ file to process.")],
     output: Annotated[Path, typer.Option("--output", "-o", help="Where to write the params artifact.")] = Path(
         "params.h5"
@@ -60,7 +61,7 @@ def build_params_cmd(
 @app.command("run")
 def run_cmd(
     ctx: typer.Context,
-    ref: Annotated[str, typer.Argument(help="Git ref or SHA to build leapfrogr at.")],
+    ref: Annotated[str, typer.Argument(help=REF_HELP)],
     params_path: Annotated[
         Path, typer.Argument(exists=True, metavar="PARAMS", help="params.h5 to run the model against.")
     ],
@@ -115,6 +116,74 @@ def diff_cmd(
         typer.echo(verdict.summary())
 
     raise typer.Exit(0 if all(v.passed for v in verdicts) else 1)
+
+
+def _compare_one_pjnz(
+    ref_workspace: BuildWorkspace,
+    candidate_workspace: BuildWorkspace,
+    pjnz: Path,
+    configuration: str,
+    tmp_dir: Path,
+) -> list[Verdict]:
+    """Run build-params/run/diff for one PJNZ file, against both workspaces."""
+    params_ref = tmp_dir / f"{pjnz.stem}-ref-params.h5"
+    params_candidate = tmp_dir / f"{pjnz.stem}-candidate-params.h5"
+    params.build_params(ref_workspace, pjnz, params_ref)
+    params.build_params(candidate_workspace, pjnz, params_candidate)
+
+    output_ref = tmp_dir / f"{pjnz.stem}-ref-output.h5"
+    output_candidate = tmp_dir / f"{pjnz.stem}-candidate-output.h5"
+    model_run.run_model(ref_workspace, params_ref, output_ref, configuration)
+    model_run.run_model(candidate_workspace, params_candidate, output_candidate, configuration)
+
+    names = sorted(indicators.INDICATORS)
+    return [_diff_one(name, output_ref, output_candidate, pjnz.stem) for name in names]
+
+
+@app.command("compare")
+def compare_cmd(
+    ctx: typer.Context,
+    ref: Annotated[str, typer.Argument(help=REF_HELP)],
+    candidate: Annotated[str, typer.Argument(help=REF_HELP)],
+    pjnz_dir: Annotated[
+        Path,
+        typer.Option(
+            "--pjnz-dir", exists=True, file_okay=False, help="Directory of PJNZ files to compare across."
+        ),
+    ],
+    configuration: Annotated[
+        str,
+        typer.Option(help="Model configuration to run, see leapfrogr::list_model_configurations()."),
+    ] = "Spectrum",
+) -> None:
+    """Run build-params/run/diff for every PJNZ in PJNZ_DIR, comparing REF against CANDIDATE.
+
+    Prints a per-indicator verdict per PJNZ file, then a per-file PASS/FAIL
+    summary line. Exits non-zero if any file fails any indicator.
+    """
+    pjnz_files = sorted(p for p in pjnz_dir.iterdir() if p.suffix.upper() == ".PJNZ")
+    if not pjnz_files:
+        typer.echo(f"No PJNZ files found in {pjnz_dir}", err=True)
+        raise typer.Exit(2)
+
+    ref_workspace = _prepare_ref(ctx.obj["repo_root"], ctx.obj["cache_dir"], ref)
+    candidate_workspace = _prepare_ref(ctx.obj["repo_root"], ctx.obj["cache_dir"], candidate)
+
+    file_results: dict[str, bool] = {}
+    with tempfile.TemporaryDirectory() as tmp:
+        for pjnz in pjnz_files:
+            typer.echo(f"\n== {pjnz.name} ==")
+            verdicts = _compare_one_pjnz(ref_workspace, candidate_workspace, pjnz, configuration, Path(tmp))
+            for verdict in verdicts:
+                typer.echo(f"  {verdict.summary()}")
+            file_results[pjnz.name] = all(v.passed for v in verdicts)
+            typer.echo(f"  {pjnz.name}: {'PASS' if file_results[pjnz.name] else 'FAIL'}")
+
+    typer.echo("\n== Summary ==")
+    for name, passed in file_results.items():
+        typer.echo(f"  {'PASS' if passed else 'FAIL'}  {name}")
+
+    raise typer.Exit(0 if all(file_results.values()) else 1)
 
 
 def main() -> None:

--- a/leapfrog-validate/src/leapfrog_validate/git_utils.py
+++ b/leapfrog-validate/src/leapfrog_validate/git_utils.py
@@ -5,8 +5,21 @@ checking out a single commit gives every interface consistent with each
 other as of that ref -- there's no cross-ref pinning problem to solve here.
 """
 
+import hashlib
+import shutil
 import subprocess
+from collections.abc import Sequence
 from pathlib import Path
+
+# The sentinel `<ref>` value meaning "the caller's own uncommitted checkout",
+# rather than a committed git ref/SHA (ticket 19's Answer).
+WORKING_TREE = "working-tree"
+
+# Directories whose content actually feeds `build.build_leapfrogr` (codegen's
+# input, its generated-header output's source, and leapfrogr itself) -- an
+# uncommitted change outside these (e.g. to this CLI) shouldn't force a
+# rebuild of the working-tree ref.
+SOURCE_DIRS_FOR_HASH = ("leapfrog-core", "codegen", "leapfrogr")
 
 
 class GitError(RuntimeError):
@@ -31,8 +44,8 @@ def find_repo_root(start: Path | None = None) -> Path:
 def resolve_ref(repo_root: Path, ref: str) -> str:
     """Resolve a committed git ref/SHA to its full commit SHA.
 
-    Only committed refs are supported -- an uncommitted working tree is
-    ticket 19, not this one.
+    Only committed refs are supported; `WORKING_TREE` is handled separately
+    by `prepare_source` since it has no SHA to resolve to.
     """
     result = subprocess.run(
         ["git", "-C", str(repo_root), "rev-parse", "--verify", f"{ref}^{{commit}}"],
@@ -68,3 +81,60 @@ def ensure_worktree(repo_root: Path, sha: str, cache_dir: Path) -> Path:
         msg = f"Could not create worktree for '{sha}' at {worktree}:\n{result.stderr}"
         raise GitError(msg)
     return worktree
+
+
+def hash_source_dirs(repo_root: Path, subdirs: Sequence[str] = SOURCE_DIRS_FOR_HASH) -> str:
+    """Content hash of `subdirs` under `repo_root`, as currently on disk (committed or not).
+
+    Stands in for a commit SHA as `materialize_working_tree`'s cache key: a
+    committed ref gets a free, cheap cache key from git; the working tree has
+    none, so re-running against unchanged content must still hash identically
+    for `build.build_leapfrogr`'s existing install-marker check to skip the
+    rebuild, exactly as it would for an unchanged ref.
+    """
+    digest = hashlib.sha256()
+    for subdir in subdirs:
+        base = repo_root / subdir
+        if not base.exists():
+            continue
+        for path in sorted(p for p in base.rglob("*") if p.is_file()):
+            digest.update(str(path.relative_to(repo_root)).encode())
+            digest.update(path.read_bytes())
+    return digest.hexdigest()[:16]
+
+
+def materialize_working_tree(repo_root: Path, cache_dir: Path) -> Path:
+    """Copy the current uncommitted working tree into an isolated, content-keyed worktree.
+
+    `build_leapfrogr` generates headers and installs into whatever worktree
+    it's pointed at; pointing it at `repo_root` directly would write those
+    build byproducts into the developer's real checkout. Keying the
+    destination by `hash_source_dirs` (rather than a fixed path) means an
+    unchanged working tree reuses the same destination -- and so the same
+    install marker -- across repeated calls, while any relevant source change
+    gets a fresh one.
+    """
+    dest = cache_dir / "worktrees" / f"{WORKING_TREE}-{hash_source_dirs(repo_root)}"
+    if dest.exists():
+        return dest
+
+    dest.mkdir(parents=True)
+    result = subprocess.run(
+        ["rsync", "-a", "--exclude=.git", f"{repo_root}/", f"{dest}/"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        shutil.rmtree(dest, ignore_errors=True)
+        msg = f"Could not materialize working tree from {repo_root} to {dest}:\n{result.stderr}"
+        raise GitError(msg)
+    return dest
+
+
+def prepare_source(repo_root: Path, cache_dir: Path, ref: str) -> Path:
+    """Resolve `ref` (a committed git ref/SHA, or `WORKING_TREE`) to a worktree to build from."""
+    if ref == WORKING_TREE:
+        return materialize_working_tree(repo_root, cache_dir)
+    sha = resolve_ref(repo_root, ref)
+    return ensure_worktree(repo_root, sha, cache_dir)

--- a/leapfrog-validate/tests/test_cli_compare.py
+++ b/leapfrog-validate/tests/test_cli_compare.py
@@ -1,0 +1,139 @@
+"""CLI-level tests for `compare`, with build-params/run mocked out.
+
+`compare`'s own job is iterating a PJNZ directory and aggregating per-file
+pass/fail -- not building or running the model, which `test_cli_integration.py`
+already covers end-to-end against real refs. Mocking `_prepare_ref`,
+`params.build_params`, and `model_run.run_model` lets these run without R.
+"""
+
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+from typer.testing import CliRunner
+
+from leapfrog_validate import cli, git_utils
+from leapfrog_validate.build import BuildWorkspace
+from leapfrog_validate.cli import app
+
+runner = CliRunner()
+
+
+def _write_output_h5(path: Path, scale: float) -> None:
+    n_year, n_sex = 2, 2
+    hc1_age, hc2_age, h_age = 2, 3, 4
+    total_age = hc1_age + hc2_age + h_age
+
+    with h5py.File(path, "w") as f:
+        f.create_dataset("p_totpop", data=np.full((n_year, n_sex, total_age), 100.0 * scale))
+        f.create_dataset("p_hivpop", data=np.full((n_year, n_sex, total_age), 10.0 * scale))
+        f.create_dataset("p_hiv_deaths", data=np.full((n_year, n_sex, total_age), 1.0 * scale))
+        f.create_dataset("h_artpop", data=np.full((n_year, n_sex, h_age, 7, 3), 1.0 * scale))
+        f.create_dataset("hc1_artpop", data=np.full((n_year, n_sex, hc1_age, 7, 3), 1.0 * scale))
+        f.create_dataset("hc2_artpop", data=np.full((n_year, n_sex, hc2_age, 6, 3), 1.0 * scale))
+        f.create_dataset("h_hiv_deaths_art", data=np.full((n_year, n_sex, h_age, 7, 3), 0.1 * scale))
+        f.create_dataset("hc1_art_aids_deaths", data=np.full((n_year, n_sex, hc1_age, 7, 3), 0.1 * scale))
+        f.create_dataset("hc2_art_aids_deaths", data=np.full((n_year, n_sex, hc2_age, 6, 3), 0.1 * scale))
+
+
+@pytest.fixture
+def fake_build_and_run(monkeypatch):
+    """Fake `_prepare_ref`/`build_params`/`run_model` driving a per-PJNZ, per-side scale.
+
+    `scales` maps a PJNZ stem to a `(ref_scale, candidate_scale)` pair; equal
+    scales produce a PASS, differing scales produce a FAIL for that file only.
+    """
+
+    def fake_prepare_ref(repo_root: Path, cache_dir: Path, ref: str) -> BuildWorkspace:
+        del repo_root, cache_dir
+        worktree = Path(f"/fake/{ref}")
+        return BuildWorkspace(worktree=worktree, r_library=worktree / "r-library")
+
+    def fake_build_params(workspace: BuildWorkspace, pjnz: Path, output: Path) -> None:
+        del workspace, pjnz, output  # compare never inspects params.h5 content
+
+    def fake_run_model(workspace: BuildWorkspace, params_path: Path, output: Path, configuration: str) -> None:
+        del configuration
+        side = "candidate" if params_path.stem.endswith("-candidate-params") else "ref"
+        pjnz_stem = params_path.stem.removesuffix(f"-{side}-params")
+        del workspace
+        ref_scale, candidate_scale = scales[pjnz_stem]
+        scale = candidate_scale if side == "candidate" else ref_scale
+        _write_output_h5(output, scale=scale)
+
+    scales: dict[str, tuple[float, float]] = {}
+    monkeypatch.setattr(cli, "_prepare_ref", fake_prepare_ref)
+    monkeypatch.setattr(cli.params, "build_params", fake_build_params)
+    monkeypatch.setattr(cli.model_run, "run_model", fake_run_model)
+    return scales
+
+
+def test_compare_flags_only_the_diverging_file(fake_build_and_run, tmp_path):
+    fake_build_and_run["matching"] = (1.0, 1.0)
+    fake_build_and_run["diverging"] = (1.0, 1.5)
+
+    pjnz_dir = tmp_path / "corpus"
+    pjnz_dir.mkdir()
+    (pjnz_dir / "matching.PJNZ").touch()
+    (pjnz_dir / "diverging.PJNZ").touch()
+
+    result = runner.invoke(app, ["compare", "main", "candidate-branch", "--pjnz-dir", str(pjnz_dir)])
+
+    assert result.exit_code == 1, result.output
+    assert "PASS  matching.PJNZ" in result.output
+    assert "FAIL  diverging.PJNZ" in result.output
+
+
+def test_compare_all_matching_files_passes(fake_build_and_run, tmp_path):
+    fake_build_and_run["a"] = (1.0, 1.0)
+    fake_build_and_run["b"] = (1.0, 1.0)
+
+    pjnz_dir = tmp_path / "corpus"
+    pjnz_dir.mkdir()
+    (pjnz_dir / "a.PJNZ").touch()
+    (pjnz_dir / "b.PJNZ").touch()
+
+    result = runner.invoke(app, ["compare", "main", "candidate-branch", "--pjnz-dir", str(pjnz_dir)])
+
+    assert result.exit_code == 0, result.output
+    assert "PASS  a.PJNZ" in result.output
+    assert "PASS  b.PJNZ" in result.output
+
+
+def test_compare_empty_pjnz_dir_errors(tmp_path):
+    pjnz_dir = tmp_path / "empty"
+    pjnz_dir.mkdir()
+
+    result = runner.invoke(app, ["compare", "main", "candidate-branch", "--pjnz-dir", str(pjnz_dir)])
+
+    assert result.exit_code == 2
+    assert "No PJNZ files found" in result.output
+
+
+def test_compare_accepts_working_tree_sentinel_as_either_side(fake_build_and_run, tmp_path, monkeypatch):
+    """The `ref`/`candidate` positional args accept `git_utils.WORKING_TREE`, not just refs.
+
+    `_prepare_ref` is mocked here (it's `git_utils.prepare_source` that does
+    the actual sentinel dispatch, covered directly in test_git_utils.py) --
+    this just pins that `compare` passes the literal string through unchanged
+    rather than rejecting or special-casing it itself.
+    """
+    fake_build_and_run["a"] = (1.0, 1.0)
+
+    pjnz_dir = tmp_path / "corpus"
+    pjnz_dir.mkdir()
+    (pjnz_dir / "a.PJNZ").touch()
+
+    seen_refs = []
+    original = cli._prepare_ref
+
+    def spy_prepare_ref(repo_root: Path, cache_dir: Path, ref: str) -> BuildWorkspace:
+        seen_refs.append(ref)
+        return original(repo_root, cache_dir, ref)
+
+    monkeypatch.setattr(cli, "_prepare_ref", spy_prepare_ref)
+    result = runner.invoke(app, ["compare", git_utils.WORKING_TREE, "main", "--pjnz-dir", str(pjnz_dir)])
+
+    assert result.exit_code == 0, result.output
+    assert seen_refs == [git_utils.WORKING_TREE, "main"]

--- a/leapfrog-validate/tests/test_cli_integration.py
+++ b/leapfrog-validate/tests/test_cli_integration.py
@@ -13,8 +13,10 @@ import subprocess
 from pathlib import Path
 
 import pytest
+from typer.testing import CliRunner
 
 from leapfrog_validate import build, git_utils, model_run, params
+from leapfrog_validate.cli import app
 from leapfrog_validate.diff import diff_indicator
 from leapfrog_validate.indicators import INDICATORS
 
@@ -22,6 +24,9 @@ requires_r = pytest.mark.skipif(shutil.which("Rscript") is None, reason="R is no
 
 REPO_ROOT = git_utils.find_repo_root(Path(__file__).parent)
 FIXTURE_PJNZ = REPO_ROOT / "leapfrogr" / "inst" / "pjnz" / "france_default.PJNZ"
+SECOND_FIXTURE_PJNZ = REPO_ROOT / "leapfrogr" / "inst" / "pjnz" / "bwa_aim-no-special-elig-numpmtct.PJNZ"
+
+runner = CliRunner()
 
 
 @pytest.fixture(scope="module")
@@ -30,8 +35,12 @@ def head_sha():
 
 
 @pytest.fixture(scope="module")
-def head_worktree(head_sha, tmp_path_factory):
-    cache_dir = tmp_path_factory.mktemp("leapfrog-validate-cache")
+def cache_dir(tmp_path_factory):
+    return tmp_path_factory.mktemp("leapfrog-validate-cache")
+
+
+@pytest.fixture(scope="module")
+def head_worktree(head_sha, cache_dir):
     worktree = git_utils.ensure_worktree(REPO_ROOT, head_sha, cache_dir)
     yield worktree
     subprocess.run(
@@ -104,3 +113,69 @@ def test_run_then_diff_of_a_ref_against_itself_passes(head_workspace, tmp_path):
 
     assert verdict.passed, verdict.summary()
     assert verdict.max_abs_diff == 0.0
+
+
+@requires_r
+def test_compare_same_ref_across_pjnz_directory_all_pass(head_workspace, head_sha, cache_dir, tmp_path):
+    """Ticket 19's acceptance case: `compare` across a directory, same ref both sides, all PASS.
+
+    Reuses `head_workspace`'s already-built cache (`cache_dir`) for both the
+    `ref` and `candidate` side of `compare`, so this doesn't trigger a second
+    build.
+    """
+    del head_workspace  # ensures the module-scoped build has already happened
+    pjnz_dir = tmp_path / "corpus"
+    pjnz_dir.mkdir()
+    shutil.copy(FIXTURE_PJNZ, pjnz_dir / FIXTURE_PJNZ.name)
+    shutil.copy(SECOND_FIXTURE_PJNZ, pjnz_dir / SECOND_FIXTURE_PJNZ.name)
+
+    result = runner.invoke(
+        app,
+        ["--cache-dir", str(cache_dir), "compare", head_sha, head_sha, "--pjnz-dir", str(pjnz_dir)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert f"PASS  {FIXTURE_PJNZ.name}" in result.output
+    assert f"PASS  {SECOND_FIXTURE_PJNZ.name}" in result.output
+
+
+@requires_r
+def test_compare_working_tree_matches_head_and_second_run_skips_build(head_workspace, head_sha, cache_dir, tmp_path):
+    """Ticket 19's other two acceptance cases, together since both need a real working-tree build.
+
+    1. Working-tree support: `working-tree` compares equal to `HEAD` (no
+       uncommitted changes exist under the hashed source dirs here), proving
+       `<ref>` really does accept a pointer to the uncommitted checkout, not
+       just committed refs.
+    2. Build-skip caching: calling `compare` a second time with no relevant
+       source change reuses the exact same materialized worktree and never
+       re-touches its install marker -- i.e. the build/codegen/compile step
+       is skipped.
+    """
+    del head_workspace
+    pjnz_dir = tmp_path / "corpus"
+    pjnz_dir.mkdir()
+    shutil.copy(FIXTURE_PJNZ, pjnz_dir / FIXTURE_PJNZ.name)
+
+    args = [
+        "--cache-dir",
+        str(cache_dir),
+        "compare",
+        git_utils.WORKING_TREE,
+        head_sha,
+        "--pjnz-dir",
+        str(pjnz_dir),
+    ]
+
+    first = runner.invoke(app, args)
+    assert first.exit_code == 0, first.output
+    assert f"PASS  {FIXTURE_PJNZ.name}" in first.output
+
+    worktree = git_utils.materialize_working_tree(REPO_ROOT, cache_dir)
+    marker = worktree / ".leapfrog-validate" / "r-library" / ".install-complete"
+    assert marker.exists()
+    marker_mtime_after_first_run = marker.stat().st_mtime_ns
+
+    second = runner.invoke(app, args)
+    assert second.exit_code == 0, second.output
+    assert marker.stat().st_mtime_ns == marker_mtime_after_first_run, "second compare run rebuilt instead of skipping"

--- a/leapfrog-validate/tests/test_git_utils.py
+++ b/leapfrog-validate/tests/test_git_utils.py
@@ -37,3 +37,69 @@ def test_ensure_worktree_is_idempotent(repo_root, tmp_path):
         ["git", "-C", str(repo_root), "worktree", "remove", "--force", str(first)],
         check=True,
     )
+
+
+@pytest.fixture
+def fake_source_tree(tmp_path):
+    """Build a minimal `repo_root`-shaped tree covering `SOURCE_DIRS_FOR_HASH`, plus an irrelevant file."""
+    for subdir in git_utils.SOURCE_DIRS_FOR_HASH:
+        (tmp_path / subdir).mkdir()
+        (tmp_path / subdir / "content.txt").write_text("original")
+    (tmp_path / "leapfrog-validate").mkdir()
+    (tmp_path / "leapfrog-validate" / "cli.py").write_text("original")
+    return tmp_path
+
+
+def test_hash_source_dirs_stable_when_content_unchanged(fake_source_tree):
+    assert git_utils.hash_source_dirs(fake_source_tree) == git_utils.hash_source_dirs(fake_source_tree)
+
+
+def test_hash_source_dirs_changes_when_hashed_dir_content_changes(fake_source_tree):
+    before = git_utils.hash_source_dirs(fake_source_tree)
+    (fake_source_tree / "leapfrogr" / "content.txt").write_text("modified")
+    after = git_utils.hash_source_dirs(fake_source_tree)
+    assert before != after
+
+
+def test_hash_source_dirs_ignores_changes_outside_hashed_dirs(fake_source_tree):
+    before = git_utils.hash_source_dirs(fake_source_tree)
+    (fake_source_tree / "leapfrog-validate" / "cli.py").write_text("modified")
+    after = git_utils.hash_source_dirs(fake_source_tree)
+    assert before == after
+
+
+def test_materialize_working_tree_copies_content_and_is_idempotent(fake_source_tree, tmp_path):
+    cache_dir = tmp_path / "cache"
+    first = git_utils.materialize_working_tree(fake_source_tree, cache_dir)
+    assert (first / "leapfrogr" / "content.txt").read_text() == "original"
+
+    second = git_utils.materialize_working_tree(fake_source_tree, cache_dir)
+    assert first == second
+
+
+def test_materialize_working_tree_uses_new_destination_when_source_changes(fake_source_tree, tmp_path):
+    cache_dir = tmp_path / "cache"
+    first = git_utils.materialize_working_tree(fake_source_tree, cache_dir)
+
+    (fake_source_tree / "codegen" / "content.txt").write_text("modified")
+    second = git_utils.materialize_working_tree(fake_source_tree, cache_dir)
+
+    assert first != second
+    assert (second / "codegen" / "content.txt").read_text() == "modified"
+
+
+def test_prepare_source_dispatches_working_tree_sentinel(fake_source_tree, tmp_path):
+    cache_dir = tmp_path / "cache"
+    resolved = git_utils.prepare_source(fake_source_tree, cache_dir, git_utils.WORKING_TREE)
+    assert resolved == git_utils.materialize_working_tree(fake_source_tree, cache_dir)
+
+
+def test_prepare_source_dispatches_committed_ref(repo_root, tmp_path):
+    resolved = git_utils.prepare_source(repo_root, tmp_path, "HEAD")
+    sha = git_utils.resolve_ref(repo_root, "HEAD")
+    assert resolved == tmp_path / "worktrees" / sha
+
+    subprocess.run(
+        ["git", "-C", str(repo_root), "worktree", "remove", "--force", str(resolved)],
+        check=True,
+    )


### PR DESCRIPTION
## Summary

Implements ticket 19 of the `leapfrog-validation` wayfinder map (`.scratch/leapfrog-validation/issues/19-compare-wrapper-working-tree.md`), building on the walking skeleton (#373) and full indicator registry (#374).

- Adds `leapfrog-validate compare <ref> <candidate> --pjnz-dir <dir>`, running `build-params`/`run`/`diff` for every `*.PJNZ` file in a directory and printing a per-indicator verdict plus a per-file PASS/FAIL summary. Exits non-zero if any file fails any indicator.
- `<ref>`/`<candidate>` now accept the literal `working-tree` in addition to a committed git ref/SHA, so you can compare your own uncommitted checkout against `main` without committing first. This is handled centrally in a new `git_utils.prepare_source`, so `build-params` and `run` gain working-tree support too, not just `compare`.
- A working-tree build is cache-keyed by a content hash of `leapfrog-core/`, `codegen/`, and `leapfrogr/` (`git_utils.hash_source_dirs`) rather than a git SHA, materialized into `<cache-dir>/worktrees/working-tree-<hash>`. This reuses `build.build_leapfrogr`'s existing install-marker skip logic unchanged, so re-running against an unchanged working tree skips the build step exactly like an unchanged committed ref does.

## Notable judgment calls

- `--cache-dir` is a global Typer option, so it must precede the subcommand (`leapfrog-validate --cache-dir <dir> compare ...`) — documented in the README.
- The "regression flags only that file" acceptance criterion is verified via a CLI-level test with build/run mocked (`test_cli_compare.py`), rather than a real one-line model regression across two git refs — kept fast and deterministic. The real-build integration tests instead cover working-tree support and build-skip caching end-to-end (`test_cli_integration.py`), including asserting the install marker's mtime is unchanged across two real `compare` invocations.
- `materialize_working_tree` rsyncs the whole repo root (excluding only `.git`) rather than filtering to just the hashed dirs — simplest correct thing at this repo's current size; worth revisiting if it gets slow.

## Test plan

- [x] `uv run pytest tests/` — 50 unit tests pass (no R required)
- [x] `uv run pytest tests/test_cli_integration.py` — 6 tests pass, including two new R-gated integration tests exercising a real build: `compare` across a directory (same ref both sides, all PASS) and `working-tree` vs `HEAD` with a verified build-skip on the second invocation
- [x] `ruff check src tests` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)