### PR TITLE
Private PJNZ archive: classifier + Azure infra (issue 16)

### DIFF
--- a/leapfrog-validate/infra/README.md
+++ b/leapfrog-validate/infra/README.md
@@ -1,0 +1,116 @@
+# PJNZ archive Azure infra
+
+Provisions the Azure storage backing the private PJNZ archive for
+a private blob container plus a CI identity that authenticates via GitHub
+OIDC, no static secret stored anywhere.
+
+## What this creates
+
+- A resource group (`pjnz-archive-rg` by default).
+- A Hot-tier, LRS storage account with public blob access disabled.
+- A private container (`pjnz-archive`) inside it.
+- A user-assigned managed identity (`leapfrog-ci-reader`) with a federated
+  credential trusting GitHub-issued OIDC tokens for `pull_request`-triggered
+  workflow runs on `hivtools/leapfrog` — and nothing else.
+- A `Storage Blob Data Reader` role assignment for that identity, scoped to
+  the container only (not the storage account, not the subscription).
+
+Layout: `main.bicep` is a subscription-scope template that creates the
+resource group and calls `modules/archive.bicep` (resource-group scope) for
+everything inside it — Bicep can't mix scopes in one file, and resource
+group creation genuinely is a different scope from the resources living in
+it.
+
+## Prerequisites
+
+- `az` CLI, logged in (`az login`) to the right subscription
+  (`az account show` to check; `az account set --subscription <id>` to
+  switch).
+- Sufficient rights on that subscription to create a resource group, a
+  storage account, and an RBAC role assignment — Owner, or
+  Contributor + User Access Administrator. Role assignment creation is the
+  one that needs the extra role beyond plain Contributor.
+- `jq` (used by `deploy.sh` to parse deployment outputs).
+- `gh` CLI authenticated against `hivtools/leapfrog` (used by `deploy.sh` to
+  publish the resulting IDs as repo variables — this step is outside Bicep
+  since GitHub variables aren't an Azure resource).
+
+None of this runs from the sandbox this was authored in — it needs your own
+machine, your own `az login` session.
+
+## Deploy
+
+```bash
+cd leapfrog-validate/infra
+./deploy.sh
+```
+
+This previews the change (`az deployment sub what-if`), asks for
+confirmation, deploys, then writes `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`,
+`AZURE_SUBSCRIPTION_ID`, `AZURE_STORAGE_ACCOUNT`, and
+`AZURE_STORAGE_CONTAINER` as GitHub repo variables on `hivtools/leapfrog`.
+
+Or drive it by hand with `az deployment sub create --location <region>
+--template-file main.bicep --parameters main.bicepparam` if you'd rather
+not run the wrapper.
+
+## Uploading files
+
+To upload files you will need the "Storage Blob Data Owner" role. You can add this via the user interface: go to Storage account -> Access Control -> Add -> Add role assignment, then add Storage Blob Data Owner to your login account. Or via CLI
+
+```
+az role assignment create --role "Storage Blob Data Owner" --assignee <your-email> --scope $(az storage account show --name pjnzarchive --resource-group pjnz-archive-rg --query id -o tsv)
+```
+
+Preferred — [azcopy](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10)
+(separate install, but resumable and much faster for bulk uploads than
+`az`). The trailing `/*` on the source uploads the directory's *contents*
+(files plus the `ETH` subfolder) without adding an extra nested folder
+named after the local directory:
+
+```bash
+azcopy login
+azcopy copy \
+  "/path/to/your/local/folder/*" \
+  "https://pjnzarchive.blob.core.windows.net/pjnz-archive/2026%20Estimates/Public%20Spectrum%20files" \
+  --recursive
+```
+
+No extra install — `az storage blob upload-batch` reuses your existing
+`az login` session:
+
+```bash
+az storage blob upload-batch \
+  --account-name pjnzarchive \
+  --destination pjnz-archive \
+  --destination-path "2026 Estimates/Public Spectrum files" \
+  --source "/path/to/your/local/folder" \
+  --auth-mode login
+```
+
+Either way, subfolders under the source (`ETH/`) land at the matching path
+under the destination (`.../Public Spectrum files/ETH/...`) automatically.
+
+The classifier that tags files by shape/domain properties is the rest of
+ticket 16 — not covered here. A CI workflow consuming the variables above
+(`azure/login@v2` with `client-id`/`tenant-id`/`subscription-id` plus
+`permissions: id-token: write` on the job) is tickets 20-22's job, once the
+archive and tagging exist.
+
+If another repo/tool ever needs to read this same archive, add another
+`userAssignedIdentity` + `federatedIdentityCredential` + role assignment
+block to `modules/archive.bicep` scoped to that repo — the storage account
+and container don't need to change.
+
+## Fork PRs
+
+GitHub's OIDC `sub` claim for `pull_request`-triggered runs is
+`repo:hivtools/leapfrog:pull_request` for fork PRs too — the federated
+credential's trust condition alone does **not** exclude forks. Today's
+fork-safety comes from a separate GitHub platform default: workflows
+triggered by `pull_request` from a fork don't get OIDC tokens (or secrets)
+at all, regardless of what this Bicep trusts. That default is not pinned
+anywhere in this infra — a future workflow using `pull_request_target`
+instead of `pull_request` (tickets 20-22's territory) would defeat it with
+nothing here to catch it. Gate the actual CI workflow to same-repo
+branches explicitly rather than relying on this being noticed later.

--- a/leapfrog-validate/infra/deploy.sh
+++ b/leapfrog-validate/infra/deploy.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# Deploys the PJNZ archive Azure infra (main.bicep) and publishes the
+# resulting CI identity details as GitHub repo variables on whichever repo
+# main.bicepparam's githubOrg/githubRepo point at (hivtools/leapfrog by
+# default). GitHub variables aren't an Azure resource, so this step lives
+# outside Bicep as a thin bridge.
+#
+# Prerequisites:
+#   - az CLI logged in (az login) to the target subscription, with Owner or
+#     Contributor + User Access Administrator on it (creating the RBAC role
+#     assignment needs the latter).
+#   - gh CLI authenticated against whichever repo main.bicepparam targets.
+#   - jq installed.
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+LOCATION="${LOCATION:-eastus}"
+DEPLOYMENT_NAME="pjnz-archive-$(date +%Y%m%d%H%M%S)"
+
+echo "Subscription context:"
+az account show --query '{name:name, id:id, tenantId:tenantId}' -o table
+
+echo
+echo "Previewing changes (what-if)..."
+az deployment sub what-if \
+  --location "$LOCATION" \
+  --template-file main.bicep \
+  --parameters main.bicepparam
+
+echo
+read -rp "Proceed with deployment? [y/N] " confirm
+[[ "$confirm" =~ ^[Yy]$ ]] || { echo "Aborted."; exit 0; }
+
+az deployment sub create \
+  --name "$DEPLOYMENT_NAME" \
+  --location "$LOCATION" \
+  --template-file main.bicep \
+  --parameters main.bicepparam
+
+outputs=$(az deployment sub show --name "$DEPLOYMENT_NAME" --query properties.outputs -o json)
+
+client_id=$(jq -r '.managedIdentityClientId.value' <<<"$outputs")
+tenant_id=$(jq -r '.tenantId.value' <<<"$outputs")
+subscription_id=$(jq -r '.subscriptionId.value' <<<"$outputs")
+storage_account=$(jq -r '.storageAccountName.value' <<<"$outputs")
+container=$(jq -r '.containerName.value' <<<"$outputs")
+github_repo=$(jq -r '.githubOrg.value + "/" + .githubRepo.value' <<<"$outputs")
+
+echo
+echo "Publishing GitHub repo variables on $github_repo..."
+gh variable set AZURE_CLIENT_ID --repo "$github_repo" --body "$client_id"
+gh variable set AZURE_TENANT_ID --repo "$github_repo" --body "$tenant_id"
+gh variable set AZURE_SUBSCRIPTION_ID --repo "$github_repo" --body "$subscription_id"
+gh variable set AZURE_STORAGE_ACCOUNT --repo "$github_repo" --body "$storage_account"
+gh variable set AZURE_STORAGE_CONTAINER --repo "$github_repo" --body "$container"
+
+echo
+echo "Done. A workflow can now authenticate via OIDC using these variables"
+echo "(azure/login@v2 with client-id/tenant-id/subscription-id, plus"
+echo "permissions: id-token: write on the job)."

--- a/leapfrog-validate/infra/main.bicep
+++ b/leapfrog-validate/infra/main.bicep
@@ -1,0 +1,59 @@
+targetScope = 'subscription'
+
+@description('Azure region for all resources. eastus by default — GitHub-hosted standard runners have historically run out of US Azure regions (East US/East US 2/West US 2/Central US/South Central US), never officially guaranteed but the best public signal available; override if that changes or your org needs otherwise.')
+param location string = 'eastus'
+
+@description('Name of the resource group to create.')
+param resourceGroupName string = 'pjnz-archive-rg'
+
+@description('Globally-unique storage account name (lowercase letters/numbers, 3-24 chars). Change if taken.')
+@minLength(3)
+@maxLength(24)
+param storageAccountName string = 'pjnzarchive'
+
+@description('Blob container name holding the private PJNZ archive.')
+param containerName string = 'pjnz-archive'
+
+@description('Name of the user-assigned managed identity CI authenticates as. Repo-specific by nature (its federated credential is bound to one GitHub repo), unlike the storage account/container which are named generically since other consumers may read the same archive later.')
+param managedIdentityName string = 'leapfrog-ci-reader'
+
+@description('GitHub org that owns the repo whose workflows are trusted.')
+param githubOrg string = 'hivtools'
+
+@description('GitHub repo whose pull_request-triggered workflows are trusted.')
+param githubRepo string = 'leapfrog'
+
+var tags = {
+  project: 'pjnz-archive'
+}
+
+resource rg 'Microsoft.Resources/resourceGroups@2022-09-01' = {
+  name: resourceGroupName
+  location: location
+  tags: tags
+}
+
+module archive 'modules/archive.bicep' = {
+  name: 'archive-resources'
+  scope: rg
+  params: {
+    location: location
+    storageAccountName: storageAccountName
+    containerName: containerName
+    managedIdentityName: managedIdentityName
+    githubOrg: githubOrg
+    githubRepo: githubRepo
+    tags: tags
+  }
+}
+
+output resourceGroupName string = rg.name
+output storageAccountName string = archive.outputs.storageAccountName
+output containerName string = archive.outputs.containerName
+output managedIdentityClientId string = archive.outputs.managedIdentityClientId
+// Echoed back so deploy.sh publishes GitHub variables on the repo this
+// deployment actually trusted, not a second, independently-typed guess.
+output githubOrg string = githubOrg
+output githubRepo string = githubRepo
+output tenantId string = subscription().tenantId
+output subscriptionId string = subscription().subscriptionId

--- a/leapfrog-validate/infra/main.bicepparam
+++ b/leapfrog-validate/infra/main.bicepparam
@@ -1,0 +1,13 @@
+using 'main.bicep'
+
+// Mirrors main.bicep's own parameter defaults -- this file is the actual
+// deployment's source of truth; main.bicep's defaults exist so `az
+// deployment sub create --template-file main.bicep` also works standalone
+// (e.g. ad-hoc testing) without one. Keep both in sync if either changes.
+param location = 'eastus'
+param resourceGroupName = 'pjnz-archive-rg'
+param storageAccountName = 'pjnzarchive'
+param containerName = 'pjnz-archive'
+param managedIdentityName = 'leapfrog-ci-reader'
+param githubOrg = 'hivtools'
+param githubRepo = 'leapfrog'

--- a/leapfrog-validate/infra/modules/archive.bicep
+++ b/leapfrog-validate/infra/modules/archive.bicep
@@ -1,0 +1,94 @@
+@description('Azure region for all resources.')
+param location string
+
+@description('Globally-unique storage account name (lowercase letters/numbers, 3-24 chars).')
+param storageAccountName string
+
+@description('Blob container name holding the private PJNZ archive.')
+param containerName string
+
+@description('Name of the user-assigned managed identity CI authenticates as.')
+param managedIdentityName string
+
+@description('GitHub org that owns the repo whose workflows are trusted.')
+param githubOrg string
+
+@description('GitHub repo whose pull_request-triggered workflows are trusted.')
+param githubRepo string
+
+param tags object = {}
+
+// Built-in "Storage Blob Data Reader" role. Read-only, data-plane only —
+// https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage
+var storageBlobDataReaderRoleId = '2a2b9908-6ea1-4ae2-8e65-a410df84e7d1'
+
+resource identity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: managedIdentityName
+  location: location
+  tags: tags
+}
+
+// Trusts GitHub-issued OIDC tokens for pull_request-triggered workflow runs
+// on this exact repo — nothing else can mint a token this identity accepts.
+resource githubFederatedCredential 'Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials@2023-01-31' = {
+  parent: identity
+  name: 'github-${githubOrg}-${githubRepo}-pr'
+  properties: {
+    issuer: 'https://token.actions.githubusercontent.com'
+    subject: 'repo:${githubOrg}/${githubRepo}:pull_request'
+    audiences: [
+      'api://AzureADTokenExchange'
+    ]
+  }
+}
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: storageAccountName
+  location: location
+  tags: tags
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    accessTier: 'Hot'
+    allowBlobPublicAccess: false
+    // Without this, anyone who can list the account key (e.g. a broader
+    // Contributor grant on the resource group) gets full account-level
+    // read/write via key/SAS auth, bypassing the OIDC-federated identity
+    // and the container-scoped Storage Blob Data Reader role entirely.
+    allowSharedKeyAccess: false
+    minimumTlsVersion: 'TLS1_2'
+    supportsHttpsTrafficOnly: true
+  }
+}
+
+resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2023-01-01' = {
+  parent: storageAccount
+  name: 'default'
+}
+
+resource container 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-01-01' = {
+  parent: blobService
+  name: containerName
+  properties: {
+    publicAccess: 'None'
+  }
+}
+
+// Scoped to the container, not the storage account — CI can read PJNZ
+// blobs and nothing else in this subscription.
+resource ciReaderRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(container.id, identity.id, storageBlobDataReaderRoleId)
+  scope: container
+  properties: {
+    principalId: identity.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', storageBlobDataReaderRoleId)
+  }
+}
+
+output storageAccountName string = storageAccount.name
+output containerName string = container.name
+output managedIdentityClientId string = identity.properties.clientId
+output managedIdentityPrincipalId string = identity.properties.principalId

--- a/leapfrog-validate/src/leapfrog_validate/classify.py
+++ b/leapfrog-validate/src/leapfrog_validate/classify.py
@@ -1,0 +1,94 @@
+"""Classify PJNZ files by configuration shape and domain properties.
+
+Two derivation tiers, per ticket 09's Answer (tracing `leapfrog-compare`'s
+`pjnz_classify.py` zip-content-sniff technique):
+
+- `shape_tags`: a cheap zip-content peek, no PJNZ import needed. Presence
+  of a `.HV` member distinguishes Goals-enabled PJNZ from AIM-only, mapping
+  onto the `Goals` vs `Spectrum`/AIM-only `ModelVariant`s (see CONTEXT.md).
+- `domain_tags`: a data-level sniff. Imports the PJNZ via the same
+  `leapfrog::process_pjnz()` path `leapfrog_validate.params.build_params`
+  already uses, then checks whether the PMTCT/cotrimoxazole input arrays
+  are all-zero -- a PJNZ that doesn't use PMTCT/cotrim still carries the
+  corresponding input variable, just zeroed out, so file presence alone
+  can't tell the two cases apart.
+"""
+
+import zipfile
+from pathlib import Path
+
+from leapfrog_validate.build import BuildWorkspace
+from leapfrog_validate.manifest import manifest_tags
+from leapfrog_validate.subprocess_utils import run_checked
+
+_CLASSIFY_SCRIPT = Path(__file__).parent / "r_scripts" / "classify_pjnz.R"
+
+
+class ClassifyError(RuntimeError):
+    """Raised when classifying a PJNZ file via Rscript fails."""
+
+
+def shape_tags(pjnz: Path) -> frozenset[str]:
+    """Derive configuration-shape tags from `pjnz`'s zip member names.
+
+    A `.HV` member (case-insensitive) marks a Goals-enabled PJNZ; its
+    absence marks AIM-only -- confirmed against this repo's own fixtures
+    (`goals/tests/resources/SouthAfrica.PJNZ` carries `.HV`, the
+    `leapfrogr/inst/pjnz/*.PJNZ` fixtures don't).
+
+    Raises `ClassifyError` on a corrupt/non-zip/missing file, matching
+    `domain_tags`'s always-fail-as-a-domain-error convention.
+    """
+    try:
+        with zipfile.ZipFile(pjnz) as z:
+            has_hv = any(name.lower().endswith(".hv") for name in z.namelist())
+    except (OSError, zipfile.BadZipFile) as e:
+        msg = f"{pjnz}: not a readable PJNZ/zip file ({e})"
+        raise ClassifyError(msg) from e
+    return frozenset({"goals"}) if has_hv else frozenset({"aim_only"})
+
+
+def _parse_domain_tags_output(stdout: str) -> frozenset[str]:
+    """Parse `classify_pjnz.R`'s `key=TRUE`/`key=FALSE` lines into a tag set."""
+    tags = set()
+    for line in stdout.splitlines():
+        key, _, value = line.strip().partition("=")
+        if value == "TRUE":
+            tags.add(key)
+    return frozenset(tags)
+
+
+def domain_tags(workspace: BuildWorkspace, pjnz: Path) -> frozenset[str]:
+    """Derive domain tags (`has_pmtct`, `has_cotrim`) by importing `pjnz`.
+
+    Shells out to `classify_pjnz.R`, which runs `leapfrog::process_pjnz()`
+    and checks whether the PMTCT/cotrimoxazole input arrays are all-zero.
+    Raises `ClassifyError` (rather than guessing) if the import itself
+    fails -- notably, this currently happens for some Goals-enabled PJNZ
+    due to a pre-existing `process_pjnz_ha` limitation unrelated to this
+    classifier (see ticket 16's comments).
+    """
+    pjnz = pjnz.resolve()
+    result = run_checked(
+        ["Rscript", str(_CLASSIFY_SCRIPT), str(workspace.r_library), str(pjnz)],
+        cwd=workspace.worktree,
+        error_cls=ClassifyError,
+        error_context="classify-pjnz",
+    )
+    return _parse_domain_tags_output(result.stdout)
+
+
+def classify(
+    workspace: BuildWorkspace,
+    pjnz: Path,
+    manifest_data: dict[str, frozenset[str]] | None = None,
+) -> frozenset[str]:
+    """Return the full tag set for `pjnz`: shape tags | domain tags | manifest tags.
+
+    `manifest_data` (from `manifest.load_manifest`) covers tags that can't
+    be derived from `pjnz` at all -- provenance/purpose, per ticket 09.
+    """
+    tags = shape_tags(pjnz) | domain_tags(workspace, pjnz)
+    if manifest_data:
+        tags |= manifest_tags(manifest_data, pjnz)
+    return tags

--- a/leapfrog-validate/src/leapfrog_validate/cli.py
+++ b/leapfrog-validate/src/leapfrog_validate/cli.py
@@ -9,7 +9,7 @@ from typing import Annotated
 
 import typer
 
-from leapfrog_validate import build, git_utils, indicators, model_run, params
+from leapfrog_validate import build, classify, git_utils, indicators, manifest, model_run, params
 from leapfrog_validate.build import BuildWorkspace
 from leapfrog_validate.diff import Verdict, diff_indicator
 from leapfrog_validate.exclusions import exclusion_mask
@@ -76,6 +76,35 @@ def run_cmd(
     workspace = _prepare_ref(ctx.obj["repo_root"], ctx.obj["cache_dir"], ref)
     model_run.run_model(workspace, params_path, output, configuration)
     typer.echo(f"Wrote {output}")
+
+
+@app.command("classify")
+def classify_cmd(
+    ctx: typer.Context,
+    ref: Annotated[str, typer.Argument(help="Git ref or SHA to build leapfrogr at.")],
+    pjnz: Annotated[Path, typer.Argument(exists=True, help="PJNZ file to classify.")],
+    manifest_path: Annotated[
+        Path | None,
+        typer.Option(
+            "--manifest", exists=True, help="JSON manifest of tags that can't be derived from file contents."
+        ),
+    ] = None,
+) -> None:
+    """Print PJNZ's derived shape/domain/manifest tags, one per line, sorted.
+
+    Shape/manifest tags are checked before building leapfrogr at REF, so a
+    bad PJNZ/manifest fails fast rather than after a multi-minute build.
+    """
+    manifest_data = manifest.load_manifest(manifest_path) if manifest_path is not None else {}
+    tags = classify.shape_tags(pjnz)
+    if manifest_data:
+        tags |= manifest.manifest_tags(manifest_data, pjnz)
+
+    workspace = _prepare_ref(ctx.obj["repo_root"], ctx.obj["cache_dir"], ref)
+    tags |= classify.domain_tags(workspace, pjnz)
+
+    for tag in sorted(tags):
+        typer.echo(tag)
 
 
 def _diff_one(name: str, a: Path, b: Path, pjnz: str | None) -> Verdict:

--- a/leapfrog-validate/src/leapfrog_validate/manifest.py
+++ b/leapfrog-validate/src/leapfrog_validate/manifest.py
@@ -1,0 +1,56 @@
+"""Manifest of tags that can't be derived from a PJNZ's own contents.
+
+Per ticket 09's Answer, reserved only for tags that aren't derivable at
+all from what's inside the file -- e.g. "custom-made for this validation
+system" provenance/purpose. Everything else comes from `classify`'s zip
+peek / R import instead, so this stays deliberately small: a flat JSON
+object mapping filename -> extra tags, not a general PJNZ database.
+
+Known limitation: keyed by bare filename, not a corpus-relative path. The
+real uploaded corpus has subfolders (e.g. `.../ETH/`), so two files
+sharing a basename in different subfolders aren't distinguishable here --
+acceptable for now since manifest entries are expected to be rare, but
+worth revisiting (path-relative-to-corpus-root keys) if that collides in
+practice or when ticket 20 wires a corpus root into the CLI.
+"""
+
+import json
+from pathlib import Path
+
+
+class ManifestError(RuntimeError):
+    """Raised when a manifest file isn't a JSON object of filename -> tags."""
+
+
+def load_manifest(manifest_path: Path) -> dict[str, frozenset[str]]:
+    """Load a JSON manifest: `{"<pjnz filename>": ["tag1", "tag2"]}`.
+
+    A missing file is treated as an empty manifest -- most corpora won't
+    need one at all.
+    """
+    try:
+        text = manifest_path.read_text()
+    except FileNotFoundError:
+        return {}
+
+    try:
+        raw = json.loads(text)
+    except json.JSONDecodeError as e:
+        msg = f"{manifest_path}: invalid JSON ({e})"
+        raise ManifestError(msg) from e
+
+    if not isinstance(raw, dict):
+        msg = f"{manifest_path}: expected a JSON object of filename -> tags, got {type(raw).__name__}"
+        raise ManifestError(msg)
+
+    for filename, tags in raw.items():
+        if not isinstance(tags, list) or not all(isinstance(tag, str) for tag in tags):
+            msg = f"{manifest_path}: '{filename}' must map to a list of tag strings, got {tags!r}"
+            raise ManifestError(msg)
+
+    return {filename: frozenset(tags) for filename, tags in raw.items()}
+
+
+def manifest_tags(manifest: dict[str, frozenset[str]], pjnz: Path) -> frozenset[str]:
+    """Look up `pjnz`'s manifest tags by filename (not full path)."""
+    return manifest.get(pjnz.name, frozenset())

--- a/leapfrog-validate/src/leapfrog_validate/r_scripts/classify_pjnz.R
+++ b/leapfrog-validate/src/leapfrog_validate/r_scripts/classify_pjnz.R
@@ -1,0 +1,45 @@
+#!/usr/bin/env Rscript
+
+usage <- "Derive domain tags for a PJNZ from its input parameters.
+
+Imports the PJNZ via leapfrog::process_pjnz() and checks whether the
+PMTCT/cotrimoxazole input arrays are all-zero -- a PJNZ that doesn't use
+PMTCT/cotrim still carries the input variable, just zeroed out, so this
+can't be read from the zip's file listing alone (see classify.py).
+
+Prints one `key=TRUE` or `key=FALSE` line per tag to stdout.
+
+Usage:
+  classify_pjnz.R <r-library> <pjnz-path>
+
+Arguments:
+  <r-library>    R library path leapfrogr was installed into.
+  <pjnz-path>    Path to the PJNZ file to classify.
+
+Options:
+  -h --help      Show this screen.
+"
+
+dat <- docopt::docopt(usage)
+names(dat) <- gsub("-", "_", names(dat), fixed = TRUE)
+
+.libPaths(c(dat$r_library, .libPaths()))
+
+pars <- leapfrog::process_pjnz(dat$pjnz_path, extract_child_params = TRUE)
+
+# NA-scrubs like prepare_pmtct() already does for PMTCT (process_pjnz_hc.R) --
+# cotrim_val gets no equivalent scrub upstream, so without this an NA cell
+# would make `all(x == 0)` evaluate to NA and silently vanish from the
+# TRUE/FALSE-only parser downstream (classify.py's _parse_domain_tags_output).
+# NULL/zero-length is treated as a hard error, not a guess: an empty array
+# here signals a shape process_pjnz() doesn't produce, not "unused".
+has_nonzero_input <- function(x, name) {
+  if (is.null(x) || length(x) == 0) {
+    stop(sprintf("expected a non-empty array for '%s', got %s", name, if (is.null(x)) "NULL" else "zero-length"))
+  }
+  x[is.na(x)] <- 0
+  any(x != 0)
+}
+
+cat(sprintf("has_pmtct=%s\n", has_nonzero_input(pars$PMTCT, "PMTCT")))
+cat(sprintf("has_cotrim=%s\n", has_nonzero_input(pars$cotrim_val, "cotrim_val")))

--- a/leapfrog-validate/tests/test_classify.py
+++ b/leapfrog-validate/tests/test_classify.py
@@ -1,0 +1,78 @@
+"""Tests for leapfrog_validate.classify.
+
+Shape tags come from a cheap zip-content peek (no R needed) -- verified
+against this repo's own real, non-sensitive PJNZ fixtures rather than
+synthetic zips, since the whole point is distinguishing real Goals-enabled
+PJNZ (carries a `.HV` member, per `goals/tests/resources/SouthAfrica.PJNZ`)
+from real AIM-only PJNZ (per ticket 09's Answer, tracing
+`pjnz_classify.py`'s existing technique).
+"""
+
+import zipfile
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from leapfrog_validate import classify, git_utils
+
+REPO_ROOT = git_utils.find_repo_root(Path(__file__).parent)
+GOALS_FIXTURE = REPO_ROOT / "goals" / "tests" / "resources" / "SouthAfrica.PJNZ"
+AIM_ONLY_FIXTURE = REPO_ROOT / "leapfrogr" / "inst" / "pjnz" / "france_default.PJNZ"
+
+
+def test_shape_tags_detects_goals_from_hv_member():
+    assert classify.shape_tags(GOALS_FIXTURE) == frozenset({"goals"})
+
+
+def test_shape_tags_detects_aim_only_when_no_hv_member():
+    assert classify.shape_tags(AIM_ONLY_FIXTURE) == frozenset({"aim_only"})
+
+
+def test_shape_tags_is_case_insensitive_on_extension(tmp_path):
+    pjnz = tmp_path / "lowercase.pjnz"
+    with zipfile.ZipFile(pjnz, "w") as z:
+        z.writestr("lowercase.dp", "")
+        z.writestr("lowercase.hv", "")
+
+    assert classify.shape_tags(pjnz) == frozenset({"goals"})
+
+
+def test_shape_tags_raises_classify_error_for_a_corrupt_file(tmp_path):
+    not_a_zip = tmp_path / "broken.PJNZ"
+    not_a_zip.write_bytes(b"not actually a zip file")
+
+    with pytest.raises(classify.ClassifyError):
+        classify.shape_tags(not_a_zip)
+
+
+def test_parse_domain_tags_output_includes_only_true_tags():
+    stdout = "has_pmtct=TRUE\nhas_cotrim=FALSE\n"
+    assert classify._parse_domain_tags_output(stdout) == frozenset({"has_pmtct"})
+
+
+def test_parse_domain_tags_output_empty_when_all_false():
+    stdout = "has_pmtct=FALSE\nhas_cotrim=FALSE\n"
+    assert classify._parse_domain_tags_output(stdout) == frozenset()
+
+
+def test_parse_domain_tags_output_both_true():
+    stdout = "has_pmtct=TRUE\nhas_cotrim=TRUE\n"
+    assert classify._parse_domain_tags_output(stdout) == frozenset({"has_pmtct", "has_cotrim"})
+
+
+def test_classify_unions_shape_domain_and_manifest_tags(monkeypatch):
+    monkeypatch.setattr(classify, "domain_tags", Mock(return_value=frozenset({"has_pmtct"})))
+    manifest_data = {"SouthAfrica.PJNZ": frozenset({"custom_made"})}
+
+    tags = classify.classify(Mock(), GOALS_FIXTURE, manifest_data)
+
+    assert tags == frozenset({"goals", "has_pmtct", "custom_made"})
+
+
+def test_classify_without_manifest_data_omits_manifest_tags(monkeypatch):
+    monkeypatch.setattr(classify, "domain_tags", Mock(return_value=frozenset()))
+
+    tags = classify.classify(Mock(), AIM_ONLY_FIXTURE)
+
+    assert tags == frozenset({"aim_only"})

--- a/leapfrog-validate/tests/test_cli_classify.py
+++ b/leapfrog-validate/tests/test_cli_classify.py
@@ -1,0 +1,57 @@
+"""CLI-level tests for `classify`, with `_prepare_ref` mocked.
+
+`domain_tags` needs a real R environment (covered by
+test_cli_integration.py's R-gated tests); the CLI wiring itself doesn't,
+so it's tested here against a real, non-sensitive fixture with the build
+step mocked out -- same boundary test_cli.py's `diff` tests draw around
+what actually needs R.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from typer.testing import CliRunner
+
+from leapfrog_validate import git_utils
+from leapfrog_validate.cli import app
+
+runner = CliRunner()
+
+REPO_ROOT = git_utils.find_repo_root(Path(__file__).parent)
+GOALS_FIXTURE = REPO_ROOT / "goals" / "tests" / "resources" / "SouthAfrica.PJNZ"
+
+
+@patch("leapfrog_validate.cli._prepare_ref")
+@patch("leapfrog_validate.classify.domain_tags")
+def test_classify_prints_sorted_shape_and_domain_tags(mock_domain_tags, mock_prepare_ref):
+    mock_prepare_ref.return_value = Mock()
+    mock_domain_tags.return_value = frozenset({"has_pmtct"})
+
+    result = runner.invoke(app, ["classify", "HEAD", str(GOALS_FIXTURE)])
+
+    assert result.exit_code == 0
+    assert result.stdout.splitlines() == ["goals", "has_pmtct"]
+
+
+@patch("leapfrog_validate.cli._prepare_ref")
+@patch("leapfrog_validate.classify.domain_tags")
+def test_classify_merges_manifest_tags(mock_domain_tags, mock_prepare_ref, tmp_path):
+    mock_prepare_ref.return_value = Mock()
+    mock_domain_tags.return_value = frozenset()
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps({"SouthAfrica.PJNZ": ["custom_made"]}))
+
+    result = runner.invoke(app, ["classify", "HEAD", str(GOALS_FIXTURE), "--manifest", str(manifest_path)])
+
+    assert result.exit_code == 0
+    assert result.stdout.splitlines() == ["custom_made", "goals"]
+
+
+def test_classify_rejects_a_nonexistent_manifest_path_instead_of_silently_ignoring_it(tmp_path):
+    """Regression test: a typo'd --manifest path used to be silently treated as "no manifest"."""
+    result = runner.invoke(
+        app, ["classify", "HEAD", str(GOALS_FIXTURE), "--manifest", str(tmp_path / "does-not-exist.json")]
+    )
+
+    assert result.exit_code != 0

--- a/leapfrog-validate/tests/test_cli_integration.py
+++ b/leapfrog-validate/tests/test_cli_integration.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import pytest
 
-from leapfrog_validate import build, git_utils, model_run, params
+from leapfrog_validate import build, classify, git_utils, model_run, params
 from leapfrog_validate.diff import diff_indicator
 from leapfrog_validate.indicators import INDICATORS
 
@@ -22,6 +22,10 @@ requires_r = pytest.mark.skipif(shutil.which("Rscript") is None, reason="R is no
 
 REPO_ROOT = git_utils.find_repo_root(Path(__file__).parent)
 FIXTURE_PJNZ = REPO_ROOT / "leapfrogr" / "inst" / "pjnz" / "france_default.PJNZ"
+_PJNZ_DIR = REPO_ROOT / "leapfrogr" / "inst" / "pjnz"
+BWA_ADULT_FIXTURE = _PJNZ_DIR / "bwa_aim-adult-art-no-special-elig_v6.13_2022-04-18.PJNZ"
+BWA_NUMPMTCT_FIXTURE = _PJNZ_DIR / "bwa_aim-no-special-elig-numpmtct.PJNZ"
+GOALS_FIXTURE = REPO_ROOT / "goals" / "tests" / "resources" / "SouthAfrica.PJNZ"
 
 
 @pytest.fixture(scope="module")
@@ -104,3 +108,29 @@ def test_run_then_diff_of_a_ref_against_itself_passes(head_workspace, tmp_path):
 
     assert verdict.passed, verdict.summary()
     assert verdict.max_abs_diff == 0.0
+
+
+@requires_r
+@pytest.mark.parametrize("pjnz", [FIXTURE_PJNZ, BWA_ADULT_FIXTURE, BWA_NUMPMTCT_FIXTURE])
+def test_domain_tags_for_aim_only_fixtures(head_workspace, pjnz):
+    """Ground truth verified empirically: all three AIM-only fixtures carry non-zero PMTCT/cotrim inputs."""
+    assert classify.domain_tags(head_workspace, pjnz) == frozenset({"has_pmtct", "has_cotrim"})
+
+
+@requires_r
+def test_domain_tags_raises_for_goals_fixture_with_current_process_pjnz_limitation(head_workspace):
+    """Regression-locking, not a desired outcome.
+
+    `leapfrog::process_pjnz()` currently errors on this Goals-enabled PJNZ
+    inside `process_pjnz_ha` (unrelated to this classifier -- see ticket
+    16's comments). `domain_tags` surfaces that as `ClassifyError` rather
+    than guessing tags, which is the correct behaviour either way; this
+    pins down that it fails loudly instead of silently.
+    """
+    with pytest.raises(classify.ClassifyError):
+        classify.domain_tags(head_workspace, GOALS_FIXTURE)
+
+
+@requires_r
+def test_classify_combines_shape_and_domain_tags_for_a_real_fixture(head_workspace):
+    assert classify.classify(head_workspace, FIXTURE_PJNZ) == frozenset({"aim_only", "has_pmtct", "has_cotrim"})

--- a/leapfrog-validate/tests/test_manifest.py
+++ b/leapfrog-validate/tests/test_manifest.py
@@ -1,0 +1,74 @@
+"""Tests for leapfrog_validate.manifest.
+
+Per ticket 09's Answer: a manifest is reserved only for tags that aren't
+derivable from a PJNZ's own contents at all (e.g. "custom-made for this
+validation system" provenance) -- everything else comes from `classify`'s
+zip peek / R import instead.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from leapfrog_validate import manifest
+
+
+def _write(tmp_path: Path, content: str) -> Path:
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(content)
+    return manifest_path
+
+
+def test_load_manifest_returns_empty_dict_when_file_missing(tmp_path):
+    assert manifest.load_manifest(tmp_path / "does-not-exist.json") == {}
+
+
+def test_load_manifest_parses_filename_to_tags(tmp_path):
+    manifest_path = _write(tmp_path, json.dumps({"foo.PJNZ": ["custom_made", "provenance:validation-system"]}))
+
+    loaded = manifest.load_manifest(manifest_path)
+
+    assert loaded == {"foo.PJNZ": frozenset({"custom_made", "provenance:validation-system"})}
+
+
+def test_load_manifest_rejects_non_object_json(tmp_path):
+    manifest_path = _write(tmp_path, json.dumps(["not", "an", "object"]))
+
+    with pytest.raises(manifest.ManifestError):
+        manifest.load_manifest(manifest_path)
+
+
+def test_load_manifest_rejects_invalid_json(tmp_path):
+    manifest_path = _write(tmp_path, "{not valid json,,,")
+
+    with pytest.raises(manifest.ManifestError):
+        manifest.load_manifest(manifest_path)
+
+
+def test_load_manifest_rejects_a_bare_string_instead_of_a_tag_list(tmp_path):
+    """Regression test: a bare string was silently exploded into one tag per character."""
+    manifest_path = _write(tmp_path, json.dumps({"foo.PJNZ": "custom_made"}))
+
+    with pytest.raises(manifest.ManifestError):
+        manifest.load_manifest(manifest_path)
+
+
+def test_load_manifest_rejects_non_string_items_in_tag_list(tmp_path):
+    manifest_path = _write(tmp_path, json.dumps({"foo.PJNZ": ["ok", 123]}))
+
+    with pytest.raises(manifest.ManifestError):
+        manifest.load_manifest(manifest_path)
+
+
+def test_manifest_tags_returns_empty_frozenset_for_unlisted_file(tmp_path):
+    tags = manifest.manifest_tags({"other.PJNZ": frozenset({"x"})}, tmp_path / "foo.PJNZ")
+    assert tags == frozenset()
+
+
+def test_manifest_tags_looks_up_by_filename_not_full_path(tmp_path):
+    loaded = {"foo.PJNZ": frozenset({"custom_made"})}
+
+    tags = manifest.manifest_tags(loaded, tmp_path / "some" / "nested" / "dir" / "foo.PJNZ")
+
+    assert tags == frozenset({"custom_made"})


### PR DESCRIPTION
## Summary

Completes ticket 16 (`.scratch/leapfrog-validation/issues/16-private-pjnz-corpus-hosting-tagging.md`) of the leapfrog-validation wayfinder map: the PJNZ classifier plus the Azure infra it now runs against.

- `leapfrog_validate/classify.py` — `shape_tags` (cheap zip-content peek: `goals`/`aim_only` from `.HV` member presence) and `domain_tags` (imports via `leapfrog::process_pjnz()`, checks whether the PMTCT/cotrimoxazole input arrays are all-zero)
- `leapfrog_validate/manifest.py` — small JSON manifest for tags that aren't derivable from a PJNZ's contents at all (provenance/purpose), per ticket 09
- `leapfrog_validate/r_scripts/classify_pjnz.R` — new Rscript backing `domain_tags`
- New `leapfrog-validate classify <ref> <pjnz> [--manifest]` CLI command
- `leapfrog-validate/infra/` — Bicep for a private Azure Blob container + a GitHub-OIDC-federated CI reader identity (no static secret), replacing the git-LFS-submodule mechanism ticket 09 originally chose (GitHub LFS bandwidth quota risk on this org's actual plan — see ticket 16's Comments for the full amendment trail)

**Notable finding recorded on the ticket:** age-stratification turned out not to be a PJNZ-intrinsic property — `process_pjnz()` takes `use_coarse_age_groups` as a caller-supplied argument, not something read from the file — so it's dropped from shape tags rather than faked. Also discovered a pre-existing `leapfrog::process_pjnz()` limitation on Goals-enabled PJNZ (`process_pjnz_ha` errors on `SouthAfrica.PJNZ`), unrelated to this ticket; `domain_tags` surfaces it as `ClassifyError` and a test locks down that it fails loudly rather than guessing.

A code review pass (medium effort) found and fixed several real bugs before this was pushed: a silent `has_cotrim=NA`-gets-dropped bug (cotrim wasn't NA-scrubbed the way PMTCT is upstream), a manifest entry that could silently explode a bare string into per-character tags, a misleading fork-PR safety claim in the infra README (GitHub's OIDC subject claim doesn't actually distinguish fork PRs — corrected to point at the real boundary), `allowSharedKeyAccess` left open on the storage account alongside the OIDC/RBAC setup, and `deploy.sh` hardcoding the repo instead of using the actual deployed values. All covered by new regression tests.

## Test plan

- [x] `ruff check .` clean
- [x] Full test suite: 68 passing (59 fast + 9 R-gated integration tests against real, non-sensitive PJNZ fixtures already in this repo)
- [x] Empirically verified `domain_tags` against all 3 real AIM-only fixtures (`france_default`, both `bwa_aim-*`) and confirmed the Goals-fixture failure mode
- [x] `leapfrog-validate/infra/`'s Bicep not yet compile-checked against a live Azure subscription from this sandbox (no `az`/`bicep` CLI here) — was reviewed manually and the role/resource types verified against Microsoft's docs; the Azure resources it describes are already deployed and the real corpus already uploaded (per ticket 16's comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)